### PR TITLE
Corrected output values for Throttle example

### DIFF
--- a/operators/operatorsTimers/operatorsThrottle.txt
+++ b/operators/operatorsTimers/operatorsThrottle.txt
@@ -26,4 +26,4 @@ For example:
         .scan(0) {i,_ in i+1}
         .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: true)
 
-The values produced are `1`, `4`, `7`, `10`, and so on.
+The values produced are `1`, `3`, `6`, `8`, and so on.


### PR DESCRIPTION
The output value for the publisher below was incorrect and did not conform to the explanation of how throttle works in this chapter. I ran the code snippet is Xcode and updated those values in the PR

```
let pub = Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()
        .scan(0) {i,_ in i+1}
        .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: true)
```